### PR TITLE
支持自动打包和自动依赖

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+*.pyc
+*.whl
+dist

--- a/__init__.py
+++ b/__init__.py
@@ -15,6 +15,17 @@ import time
 from bpy.types import Operator, Panel, PropertyGroup
 from bpy.props import FloatProperty, PointerProperty, BoolProperty
 
+
+if "inputs" in locals():
+    import importlib
+
+    wheels = importlib.reload(wheels)
+    wheels.load_wheels()
+else:
+    from . import wheels
+
+    wheels.load_wheels()
+
 # 动态检测函数
 def check_gamepad_available():
     try:

--- a/scripts/build_wheel.py
+++ b/scripts/build_wheel.py
@@ -1,0 +1,24 @@
+import sys
+import os
+import subprocess
+
+
+def download_dep(dep_name: str, target_dir: str):
+    args = [
+        sys.executable,
+        "-m",
+        "pip",
+        "wheel",
+        dep_name,
+        "-w",
+        target_dir,
+    ]
+    subprocess.run(args)
+
+
+deps = ["inputs==0.5"]
+
+
+def download_all(wheel_dir: str):
+    for dep in deps:
+        download_dep(dep, wheel_dir)

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -2,23 +2,15 @@ import os
 import pathlib
 import subprocess
 import zipfile
-import sys
-import platform
 import build_wheel
 
-platform_name_alias = {
-    "Windows": "win",
-    "Linux": "linux",
-    "Darwin": "macOS"
-}
-blender_matrix = {"310": "blender3.3-4.0", "311": "blender4.1"}
 
 project_path = pathlib.Path(__file__).parent.parent.absolute()
 
 
-def do_pack(wheel_dir: pathlib.Path, dist_path: pathlib.Path, blender_version: str, platform_key: str):
+def do_pack(wheel_dir: pathlib.Path, dist_path: pathlib.Path):
     branch = "main"
-    packing_file = f"BGC-{blender_version}-{platform_key}.zip"
+    packing_file = f"BGC.zip"
     print(f"Packing for {packing_file}")
     packing_file = str(dist_path.joinpath(packing_file))
     subprocess.run(
@@ -55,13 +47,8 @@ def main():
         print(f"Creating dist_folder at {dist_path}")
         os.mkdir(dist_path)
 
-    assert platform.system() in platform_name_alias
-    platform_key = f"{platform_name_alias[platform.system()]}_{platform.machine()}"
-    python_code = f"{sys.version_info.major}{sys.version_info.minor}"
-    assert python_code in blender_matrix
-
     build_wheel.download_all(str(wheel_dir))
-    output_file = do_pack(wheel_dir, dist_path, blender_matrix[python_code], platform_key)
+    output_file = do_pack(wheel_dir, dist_path)
     print(f"Output file localed at {output_file}")
 
 

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -1,0 +1,69 @@
+import os
+import pathlib
+import subprocess
+import zipfile
+import sys
+import platform
+import build_wheel
+
+platform_name_alias = {
+    "Windows": "win",
+    "Linux": "linux",
+    "Darwin": "macOS"
+}
+blender_matrix = {"310": "blender3.3-4.0", "311": "blender4.1"}
+
+project_path = pathlib.Path(__file__).parent.parent.absolute()
+
+
+def do_pack(wheel_dir: pathlib.Path, dist_path: pathlib.Path, blender_version: str, platform_key: str):
+    branch = "main"
+    packing_file = f"BGC-{blender_version}-{platform_key}.zip"
+    print(f"Packing for {packing_file}")
+    packing_file = str(dist_path.joinpath(packing_file))
+    subprocess.run(
+        [
+            "git",
+            "archive",
+            "--format",
+            "zip",
+            "--output",
+            packing_file,
+            branch,
+            "--prefix",
+            "BGC/",
+        ]
+    )
+
+    wheels = list(
+        map(
+            lambda x: str(wheel_dir.joinpath(x)),
+            filter(lambda x: x.endswith(".whl"), os.listdir(wheel_dir)),
+        )
+    )
+    for wheel in wheels:
+        with zipfile.ZipFile(packing_file, "a") as zfile:
+            zfile.write(wheel, f"BGC/wheels/{os.path.basename(wheel)}")
+    return packing_file
+
+
+def main():
+    wheel_dir = project_path.joinpath("wheels")
+    dist_path = project_path.joinpath("dist")
+    print(f"Project is located at {str(project_path)}")
+    if not dist_path.exists():
+        print(f"Creating dist_folder at {dist_path}")
+        os.mkdir(dist_path)
+
+    assert platform.system() in platform_name_alias
+    platform_key = f"{platform_name_alias[platform.system()]}_{platform.machine()}"
+    python_code = f"{sys.version_info.major}{sys.version_info.minor}"
+    assert python_code in blender_matrix
+
+    build_wheel.download_all(str(wheel_dir))
+    output_file = do_pack(wheel_dir, dist_path, blender_matrix[python_code], platform_key)
+    print(f"Output file localed at {output_file}")
+
+
+if __name__ == "__main__":
+    main()

--- a/wheels/__init__.py
+++ b/wheels/__init__.py
@@ -1,0 +1,82 @@
+# ##### BEGIN GPL LICENSE BLOCK #####
+#
+#  This program is free software; you can redistribute it and/or
+#  modify it under the terms of the GNU General Public License
+#  as published by the Free Software Foundation; either version 2
+#  of the License, or (at your option) any later version.
+#
+#  This program is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU General Public License for more details.
+#
+#  You should have received a copy of the GNU General Public License
+#  along with this program; if not, write to the Free Software Foundation,
+#  Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+#
+# ##### END GPL LICENSE BLOCK #####
+
+"""External dependencies loader."""
+
+import glob
+import os.path
+import sys
+import logging
+
+my_dir = os.path.join(os.path.dirname(__file__))
+log = logging.getLogger(__name__)
+
+
+def load_wheel(module_name, fname_prefix):
+    """Loads a wheel from 'fname_prefix*.whl', unless the named module can be imported.
+
+    This allows us to use system-installed packages before falling back to the shipped wheels.
+    This is useful for development, less so for deployment.
+    """
+
+    try:
+        module = __import__(module_name)
+    except ImportError as ex:
+        log.debug("Unable to import %s directly, will try wheel: %s", module_name, ex)
+    else:
+        log.debug(
+            "Was able to load %s from %s, no need to load wheel %s",
+            module_name,
+            module.__file__,
+            fname_prefix,
+        )
+        return
+
+    sys.path.append(wheel_filename(fname_prefix))
+    module = __import__(module_name)
+    log.debug("Loaded %s from %s", module_name, module.__file__)
+
+
+def wheel_filename(fname_prefix: str) -> str:
+    path_pattern = os.path.join(my_dir, "%s*.whl" % fname_prefix)
+    wheels = glob.glob(path_pattern)
+    if not wheels:
+        raise RuntimeError("Unable to find wheel at %r" % path_pattern)
+
+    # If there are multiple wheels that match, load the last-modified one.
+    # Alphabetical sorting isn't going to cut it since BAT 1.10 was released.
+    def modtime(filename: str) -> float:
+        return os.stat(filename).st_mtime
+
+    wheels.sort(key=modtime)
+    return wheels[-1]
+
+
+def load_wheels():
+
+    module_name = "inputs"
+    fname_prefix = "inputs"
+    load_wheel(module_name, fname_prefix)
+
+
+if __name__ == "__main__":
+    load_wheels()
+    import inputs
+
+    print(inputs)
+    print("Loading wheel completed")


### PR DESCRIPTION
自动打包成 zip 并附带 `inputs` 依赖， 启动时自动加载依赖（blender推荐方式）。
**避免手动安装依赖（会影响blender 的python 环境）**

---
主要代码来自我的一个项目。可能需要调整一下包的名称因为`inputs`包是通用的，不需要区分系统和架构。
现在还是草稿，如果需要这个修改可以回复下。（能正常直接打包，并且提供给blender使用）

---
打包方式：
1. 手动打包： 用blender的python 执行 `./scripts/release.py`，输出一个 `BGC-blender4.1-win_AMD64.zip`
2. 使用CI打包